### PR TITLE
Emit TaxCurrencyCode (BT-6) only when it differs from the invoice currency (closes #7)

### DIFF
--- a/src/Builders/ApplicableHeaderTradeSettlement.php
+++ b/src/Builders/ApplicableHeaderTradeSettlement.php
@@ -13,8 +13,13 @@ class ApplicableHeaderTradeSettlement
 
         if ($invoice->profile->isAtLeast(Profile::BASIC_WL)) {
             $xml .= CreditorReferenceID::build($invoice->bankAssignedCreditorIdentifier) .
-                PaymentReference::build($invoice->remittanceInformation) .
-                TaxCurrencyCode::build($invoice->vatCurrency);
+                PaymentReference::build($invoice->remittanceInformation);
+
+            // BT-6 (VAT accounting currency) must only be present when it differs from
+            // BT-5 (invoice currency). Emitting it when both are equal violates rule BR-53.
+            if ($invoice->vatCurrency !== $invoice->currencyCode) {
+                $xml .= TaxCurrencyCode::build($invoice->vatCurrency);
+            }
         }
 
         $xml .= '<ram:InvoiceCurrencyCode>' . $invoice->currencyCode . '</ram:InvoiceCurrencyCode>';


### PR DESCRIPTION
Fixes #7.

## Problem
`ApplicableHeaderTradeSettlement` emitted `TaxCurrencyCode` (BT-6) unconditionally from `$invoice->vatCurrency`, which defaults to `EUR` — identical to `$invoice->currencyCode` for any normal EUR invoice. Per the official Factur-X 1.08 EN16931 Schematron, rule **BR-53** requires:

> the VAT accounting currency code (BT-6) … and `not(TaxCurrencyCode = InvoiceCurrencyCode)`

so a `TaxCurrencyCode` equal to the invoice currency is a validation error (and implies the phantom BT-111).

## Fix
Gate the `TaxCurrencyCode` emission on `$invoice->vatCurrency !== $invoice->currencyCode`.

## Verification
- New behaviour, EUR/EUR: no `<ram:TaxCurrencyCode>` emitted, XSD-valid.
- USD vat currency vs EUR invoice currency: `<ram:TaxCurrencyCode>USD</ram:TaxCurrencyCode>` present, XSD-valid.
- `composer validate --strict`, `php -l`, `phpcs`, `rector --dry-run` all pass.

## Note for maintainer (out of scope)
`vatCurrency` currently feeds both BT-6 *and* the `currencyID` of the main `TaxTotalAmount` (BT-110), while the BT-111 amount comes from the separate `vatAccountingCurrencyCode`/`totalVATAmountInAccountingCurrency` pair. That conflation only matters in the rare multi-currency case and is left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)