### PR TITLE
Allow choosing the seller/buyer electronic address scheme (closes #8)

### DIFF
--- a/src/Builders/BuyerTradeParty.php
+++ b/src/Builders/BuyerTradeParty.php
@@ -32,7 +32,7 @@ class BuyerTradeParty
 
         if ($profile->isAtLeast(Profile::BASIC_WL)) {
             $xml .= PostalTradeAddress::build($buyer->address, $profile);
-            $xml .= Email::build($buyer->email);
+            $xml .= Email::build($buyer->email, $buyer->emailSchemeIdentifier);
             $xml .= SpecifiedTaxRegistration::build($buyer->vatIdentifier);
         }
         return $xml . '</ram:BuyerTradeParty>';

--- a/src/Builders/Email.php
+++ b/src/Builders/Email.php
@@ -3,15 +3,22 @@
 namespace MahdiAbderraouf\FacturX\Builders;
 
 use MahdiAbderraouf\FacturX\Enums\SchemeIdentifier;
+use MahdiAbderraouf\FacturX\Helpers\Utils;
 
 class Email
 {
-    public static function build(?string $email = null): string
-    {
+    public static function build(
+        ?string $email = null,
+        SchemeIdentifier|string $schemeIdentifier = SchemeIdentifier::EMAIL
+    ): string {
         $xml = '';
 
         if ($email) {
-            $schemeId = SchemeIdentifier::EMAIL->value;
+            $schemeId = htmlspecialchars(
+                Utils::stringOrEnumToString($schemeIdentifier),
+                ENT_XML1 | ENT_QUOTES,
+                'UTF-8'
+            );
             $xml .= <<<XML
             <ram:URIUniversalCommunication>
                 <ram:URIID schemeID="{$schemeId}">{$email}</ram:URIID>

--- a/src/Builders/SellerTradeParty.php
+++ b/src/Builders/SellerTradeParty.php
@@ -28,7 +28,7 @@ class SellerTradeParty
         $xml .= PostalTradeAddress::build($seller->address, $profile);
 
         if ($profile->isAtLeast(Profile::BASIC_WL)) {
-            $xml .= Email::build($seller->email);
+            $xml .= Email::build($seller->email, $seller->emailSchemeIdentifier);
         }
 
         $xml .= SpecifiedTaxRegistration::build($seller->vatIdentifier);

--- a/src/Enums/SchemeIdentifier.php
+++ b/src/Enums/SchemeIdentifier.php
@@ -11,6 +11,7 @@ enum SchemeIdentifier: string
     case SIRET = '0009';
     case SIREN = '0002';
     case EMAIL = 'EM';
+    case FRCTC_ELECTRONIC_ADDRESS = '0225';
     case SWIFT = '0021';
     case DUNS = '0060';
     case GLN = '0088';

--- a/src/Models/Buyer.php
+++ b/src/Models/Buyer.php
@@ -9,9 +9,13 @@ class Buyer
 {
     public string $schemeIdentifier = '0009';
 
+    public string $emailSchemeIdentifier = 'EM';
+
     /**
      * @param array<array> $globalIdentifiers Global identifiers when schemeIdentifier is known :
      *      [['id' => string, 'schemeIdentifier' => SchemeIdentifier|string], ...]
+     * @param SchemeIdentifier|string $emailSchemeIdentifier Scheme of the electronic address (BT-49-1),
+     *      e.g. SchemeIdentifier::EMAIL ('EM') or SchemeIdentifier::FRCTC_ELECTRONIC_ADDRESS ('0225').
      */
     public function __construct(
         public string $name,
@@ -24,9 +28,11 @@ class Buyer
         public ?array $globalIdentifiers = null,
         public ?string $vatIdentifier = null,
         public ?string $buyerReference = null,
-        public ?string $accountingReference = null
+        public ?string $accountingReference = null,
+        SchemeIdentifier|string $emailSchemeIdentifier = SchemeIdentifier::EMAIL,
     ) {
         $this->schemeIdentifier = Utils::stringOrEnumToString($schemeIdentifier);
+        $this->emailSchemeIdentifier = Utils::stringOrEnumToString($emailSchemeIdentifier);
     }
 
     public static function createFromArray(array $data): self
@@ -41,7 +47,8 @@ class Buyer
             globalIdentifiers: $data['globalIdentifiers'] ?? null,
             vatIdentifier: $data['vatIdentifier'] ?? null,
             buyerReference: $data['buyerReference'] ?? null,
-            accountingReference: $data['accountingReference'] ?? null
+            accountingReference: $data['accountingReference'] ?? null,
+            emailSchemeIdentifier: $data['emailSchemeIdentifier'] ?? SchemeIdentifier::EMAIL,
         );
     }
 }

--- a/src/Models/Seller.php
+++ b/src/Models/Seller.php
@@ -9,9 +9,13 @@ class Seller
 {
     public string $schemeIdentifier = '0009';
 
+    public string $emailSchemeIdentifier = 'EM';
+
     /**
      * @param array<array> $globalIdentifiers Global identifiers when schemeIdentifier is known :
      *      [['id' => string, 'schemeIdentifier' => SchemeIdentifier|string], ...]
+     * @param SchemeIdentifier|string $emailSchemeIdentifier Scheme of the electronic address (BT-34-1),
+     *      e.g. SchemeIdentifier::EMAIL ('EM') or SchemeIdentifier::FRCTC_ELECTRONIC_ADDRESS ('0225').
      */
     public function __construct(
         public string $name,
@@ -25,8 +29,10 @@ class Seller
         public ?array $globalIdentifiers = null,
         public ?string $tradingName = null,
         public ?TaxRespresentative $taxRespresentative = null,
+        SchemeIdentifier|string $emailSchemeIdentifier = SchemeIdentifier::EMAIL,
     ) {
         $this->schemeIdentifier = Utils::stringOrEnumToString($schemeIdentifier);
+        $this->emailSchemeIdentifier = Utils::stringOrEnumToString($emailSchemeIdentifier);
     }
 
     public static function createFromArray(array $data): self
@@ -44,6 +50,7 @@ class Seller
             taxRespresentative: isset($data['taxRespresentative'])
                 ? TaxRespresentative::createFromArray($data['taxRespresentative'])
                 : null,
+            emailSchemeIdentifier: $data['emailSchemeIdentifier'] ?? SchemeIdentifier::EMAIL,
         );
     }
 }


### PR DESCRIPTION
Fixes #8.

## Problem
The seller (BT-34) and buyer (BT-49) electronic address was always emitted with `schemeID="EM"`, so a French CTC SIREN-based address (`schemeID` `0225`) could not be produced. BR-FR-13/22 require that scheme for self-billed e-invoices.

## Fix
- Add `SchemeIdentifier::FRCTC_ELECTRONIC_ADDRESS` (`0225`) — a valid EAS code (confirmed against the official EAS code list, id 18).
- Add an optional `emailSchemeIdentifier` to `Seller` and `Buyer` (default `SchemeIdentifier::EMAIL`), plumbed through to `Email::build()`. The parameter is **appended last**, so existing positional callers are unaffected and the default output is unchanged.
- Escape the `schemeID` attribute, since it is now caller-supplied, to avoid widening the XML-injection surface.

```php
// FR CTC self-billed seller address
'seller' => [
    'email' => '123456789',
    'emailSchemeIdentifier' => SchemeIdentifier::FRCTC_ELECTRONIC_ADDRESS, // 0225
],
```

## Design note
I chose an **explicit parameter** over the `@`-detection heuristic from the issue (per discussion with the maintainer): it matches the existing explicit-`schemeIdentifier` patterns, is fully backwards compatible, and avoids implicit magic.

The BT-21/BT-22 processing-instructions note (subject `BAR`, content `B2B`) required by BR-FR-22 is **already** expressible today via `Note(note: 'B2B', noteSubjectCode: NoteSubjectCode::PROCESSING_INSTRUCTIONS)`, so no change is needed there. I deliberately did **not** add the FR-CTC content enum proposed in the issue, as those `B2B`/`B2BINT`/… values are CTC/PPF-specific and not part of the Factur-X XSD/Schematron — happy to add it if you'd like.

⚠️ Note: BR-FR-* are French CTC/PPF rules and are **not** in the Factur-X XSD/Schematron, so `Validator` does not enforce them either way.

## Verification
- Default seller/buyer email still emits `schemeID="EM"` (×2), no `0225`, XSD-valid.
- Explicit `0225` via both enum (seller) and string (buyer) emits `schemeID="0225"`, XSD-valid.
- `composer validate --strict`, `php -l`, `phpcs`, `rector --dry-run` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)