### PR TITLE
Fix VAT currency model so BT-110/BT-6/BT-111 map to the right currencies (closes #13)

### DIFF
--- a/examples/4.minimum_profile_complete.php
+++ b/examples/4.minimum_profile_complete.php
@@ -48,7 +48,6 @@ $invoice = Invoice::createFromArray([
     'businessProcessType' => 'A2', // default A1
     'purchaseOrderReference' => 'PO-202400005',
     'currencyCode' => 'EUR', // default EUR
-    'vatCurrency' => 'USD', // default EUR
 ]);
 
 try {

--- a/examples/5.basicwl_profile_complete.php
+++ b/examples/5.basicwl_profile_complete.php
@@ -67,6 +67,7 @@ $invoice = Invoice::createFromArray([
             'province' => 'Auvergne-Rhône-Alpes',
         ],
         'email' => 'sales@acmecorp.com',
+        'emailSchemeIdentifier' => SchemeIdentifier::EMAIL, // default EM; use FRCTC_ELECTRONIC_ADDRESS (0225) for a SIREN address
         'legalRegistrationIdentifier' => 'SIRET-SELLER-67890',
         'identifiers' => ['S-2001'],
         'globalIdentifiers' => [

--- a/examples/6.basic_profile_complete.php
+++ b/examples/6.basic_profile_complete.php
@@ -68,6 +68,7 @@ $invoice = Invoice::createFromArray([
             'province' => 'Auvergne-Rhône-Alpes',
         ],
         'email' => 'sales@acmecorp.com',
+        'emailSchemeIdentifier' => SchemeIdentifier::EMAIL, // default EM; use FRCTC_ELECTRONIC_ADDRESS (0225) for a SIREN address
         'legalRegistrationIdentifier' => 'SIRET-SELLER-67890',
         'identifiers' => ['S-2001'],
         'globalIdentifiers' => [

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,6 @@ $invoice = Invoice::createFromArray([
     'businessProcessType' => 'A2', // default A1
     'purchaseOrderReference' => 'PO-202400005',
     'currencyCode' => 'EUR', // default EUR
-    'vatCurrency' => 'USD', // default EUR
 ]);
 
 $xml = $invoice->toXml();

--- a/src/Builders/ApplicableHeaderTradeSettlement.php
+++ b/src/Builders/ApplicableHeaderTradeSettlement.php
@@ -15,10 +15,12 @@ class ApplicableHeaderTradeSettlement
             $xml .= CreditorReferenceID::build($invoice->bankAssignedCreditorIdentifier) .
                 PaymentReference::build($invoice->remittanceInformation);
 
-            // BT-6 (VAT accounting currency) must only be present when it differs from
-            // BT-5 (invoice currency). Emitting it when both are equal violates rule BR-53.
-            if ($invoice->vatCurrency !== $invoice->currencyCode) {
-                $xml .= TaxCurrencyCode::build($invoice->vatCurrency);
+            if (
+                $invoice->vatAccountingCurrencyCode
+                && $invoice->vatAccountingCurrencyCode !== $invoice->currencyCode
+                && $invoice->totalVATAmountInAccountingCurrency !== null
+            ) {
+                $xml .= TaxCurrencyCode::build($invoice->vatAccountingCurrencyCode);
             }
         }
 

--- a/src/Builders/SpecifiedTradeSettlementHeaderMonetarySummation.php
+++ b/src/Builders/SpecifiedTradeSettlementHeaderMonetarySummation.php
@@ -24,12 +24,13 @@ class SpecifiedTradeSettlementHeaderMonetarySummation
         }
 
         $xml .= '<ram:TaxBasisTotalAmount>' . $invoice->totalAmountWithoutVAT . '</ram:TaxBasisTotalAmount>';
-        $xml .= '<ram:TaxTotalAmount currencyID="' . $invoice->vatCurrency . '">'
+        $xml .= '<ram:TaxTotalAmount currencyID="' . $invoice->currencyCode . '">'
             . $invoice->totalVATAmount . '</ram:TaxTotalAmount>';
 
         if (
             $invoice->profile->isAtLeast(Profile::BASIC_WL)
             && $invoice->vatAccountingCurrencyCode
+            && $invoice->vatAccountingCurrencyCode !== $invoice->currencyCode
             && $invoice->totalVATAmountInAccountingCurrency !== null
         ) {
             $xml .= '<ram:TaxTotalAmount currencyID="' . $invoice->vatAccountingCurrencyCode . '">'

--- a/src/Models/Invoice.php
+++ b/src/Models/Invoice.php
@@ -26,6 +26,8 @@ class Invoice
      *           'issueDate' => new DateTime(),
      *      ],
      *  ]
+     * @param string $vatCurrency @deprecated 2.1.0 Unused: BT-110 uses $currencyCode and BT-6/BT-111
+     *      derive from $vatAccountingCurrencyCode. Kept for backward compatibility, to be removed in 3.0.0.
      */
     public function __construct(
         public Profile $profile,


### PR DESCRIPTION
Fixes #13.

## Problem
`Invoice` carried three currency fields (`currencyCode`, `vatCurrency`, `vatAccountingCurrencyCode`) for EN16931's two currencies. `vatCurrency` was used as **both** the BT-110 `TaxTotalAmount/@currencyID` and the BT-6 `TaxCurrencyCode`, so the main VAT total was mislabelled and BT-6 was decoupled from the BT-111 accounting amount — a valid BT-6/BT-111 pair could not be produced.

## Fix
- **BT-110** `TaxTotalAmount/@currencyID` now uses `currencyCode` (BT-5).
- **BT-6** `TaxCurrencyCode` and the **BT-111** `TaxTotalAmount` both derive from `vatAccountingCurrencyCode`, emitted together only when it is set and differs from `currencyCode` (satisfies BR-53).
- `vatCurrency` is now unused and marked `@deprecated` — kept for backward compatibility, to be removed in 3.0.0.

Backwards-compatible: the constructor signature is unchanged, and single-currency invoices (the overwhelming majority) produce identical output.

## Verification
- Single-currency EUR: BT-110 in `EUR`, no `TaxCurrencyCode`, one `TaxTotalAmount`.
- Accounting currency `USD`: BT-110 in `EUR`, `TaxCurrencyCode=USD`, BT-111 `TaxTotalAmount` in `USD`, two `TaxTotalAmount` total.
- Deprecated `vatCurrency` set: no effect on output.
- Accounting currency == invoice currency: no `TaxCurrencyCode`, no duplicate `TaxTotalAmount`.
- All XSD-valid; `composer validate --strict`, `php -l`, `phpcs`, `rector --dry-run` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)